### PR TITLE
feat: add hide pre-releases toggle

### DIFF
--- a/src/lib/components/repo/RepoReleases.svelte
+++ b/src/lib/components/repo/RepoReleases.svelte
@@ -9,6 +9,7 @@
     type GroupedReleases,
     type PackageGroup,
   } from '$lib/utils/release-grouping';
+  import { isPrerelease } from '$lib/utils/semver';
   import GroupListItem from '$lib/components/repo/GroupListItem.svelte';
   import GroupCardItem from '$lib/components/repo/GroupCardItem.svelte';
 
@@ -33,19 +34,48 @@
 
   // Filter options
   let filterText = $state('');
+  let hidePrereleases = $state(false);
 
   // Sorting options
   let sortBy = $state<'name' | 'count' | 'date'>('name');
   let sortOrder = $state<'asc' | 'desc'>('asc');
 
+  function isStableRelease(r: Release): boolean {
+    return !r.prerelease && !isPrerelease(r.tag_name);
+  }
+
   let sortedGroups: PackageGroup[] = $derived.by(() => {
     if (!groupedReleases) return [];
+
     let groups = groupedReleases.groups;
+
+    if (hidePrereleases) {
+      groups = groups
+        .map((group) => {
+          const filtered = group.releases.filter(isStableRelease);
+          if (filtered.length === 0) return null;
+          return {
+            ...group,
+            releases: filtered,
+            latestRelease: filtered[0],
+            releaseCount: filtered.length,
+          } satisfies PackageGroup;
+        })
+        .filter((g): g is PackageGroup => g !== null);
+    }
 
     const searchTerm = filterText.toLowerCase();
     groups = groups.filter((group) => group.name.toLowerCase().includes(searchTerm));
 
     return sortPackageGroups(groups, sortBy, sortOrder);
+  });
+
+  let filteredReleaseCount = $derived.by(() => {
+    if (!groupedReleases) return 0;
+    if (!hidePrereleases) return groupedReleases.totalReleases;
+    return groupedReleases.groups
+      .map((group) => group.releases.filter(isStableRelease))
+      .reduce((sum, releases) => sum + releases.length, 0);
   });
   let singlePackageView = $derived(sortedGroups.length === 1);
 
@@ -248,6 +278,29 @@
           </button>
         </div>
 
+        <!-- Pre-release filter -->
+        <button
+          class="btn btn-sm {hidePrereleases ? 'btn-active' : ''}"
+          onclick={() => (hidePrereleases = !hidePrereleases)}
+          aria-label="Hide pre-releases"
+          aria-pressed={hidePrereleases}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><path d="M12 20h9" /><path
+              d="M16.376 3.622a1 1 0 013.002 3.002L7.368 18.635a2 2 0 01-.855.506l-2.872.838a.5.5 0 01-.62-.62l.838-2.872a2 2 0 01.506-.854z"
+            /></svg
+          >
+          Hide pre-releases
+        </button>
+
         <!-- View Controls -->
         <div class="join" role="group" aria-label="View options">
           <button
@@ -388,7 +441,12 @@
           <div>
             <h2 class="text-lg font-semibold">Repository Summary</h2>
             <p class="text-sm text-gray-600 dark:text-gray-300">
-              Found {groupedReleases.totalReleases} releases across {groupedReleases.groups.length} packages
+              {#if hidePrereleases}
+                Showing {filteredReleaseCount} of {groupedReleases.totalReleases} releases across
+                {sortedGroups.length} packages
+              {:else}
+                Found {groupedReleases.totalReleases} releases across {groupedReleases.groups.length} packages
+              {/if}
             </p>
           </div>
           {#if apiResponse?.meta?.rateLimit}

--- a/src/lib/utils/release-grouping.semver.test.ts
+++ b/src/lib/utils/release-grouping.semver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { groupReleasesByPackage } from './release-grouping';
+import { isPrerelease } from './semver';
 import type { Release } from '$lib/services/repo-api';
 
 function makeRelease(id: number, tag: string, dateISO: string, name?: string): Release {
@@ -39,5 +40,25 @@ describe('groupReleasesByPackage — semver normalization of versions', () => {
     expect(versions).toContain('3.4.5');
     // Unparsable should remain as-is
     expect(versions).toContain('not-a-version');
+  });
+});
+
+describe('isPrerelease', () => {
+  it.each([
+    ['1.2.3', false],
+    ['v1.2.3', false],
+    ['1.2.3-alpha.1', true],
+    ['v1.2.3-beta.0', true],
+    ['2.0.0-rc.1', true],
+    ['3.0.0-next.4', true],
+    ['1.0.0-canary.20240101', true],
+    ['refs/tags/v2.0.0-beta.1', true],
+    ['0.0.1', false],
+    ['not-a-version', false],
+    ['', false],
+    [null, false],
+    [undefined, false],
+  ])('isPrerelease(%j) === %s', (input, expected) => {
+    expect(isPrerelease(input as string | null | undefined)).toBe(expected);
   });
 });

--- a/src/lib/utils/semver.ts
+++ b/src/lib/utils/semver.ts
@@ -1,4 +1,4 @@
-import { compare as semverCompare, clean as semverClean, coerce as semverCoerce } from 'semver';
+import { compare as semverCompare, clean as semverClean, coerce as semverCoerce, parse as semverParse } from 'semver';
 
 /**
  * Normalize/clean a version-like string using the semver package (loose mode).
@@ -19,6 +19,26 @@ export function normalizeVersion(input?: string | null): string | null {
   if (cleaned) return cleaned;
   const coerced = semverCoerce(stripped, { loose: true });
   return coerced ? coerced.version : null;
+}
+
+/**
+ * Detect whether a version-like string contains a semver pre-release segment.
+ * Parses the raw input directly (strips `refs/tags/` and `v` prefix) and checks
+ * for pre-release identifiers (e.g. `-alpha.1`, `-beta.0`, `-rc.2`).
+ * Returns false for non-parsable inputs.
+ */
+export function isPrerelease(version?: string | null): boolean {
+  const raw = (version || '').trim();
+  if (!raw) return false;
+  const stripped = raw
+    .replace(/^refs\/tags\//i, '')
+    .replace(/^v(?=\d)/i, '')
+    .trim();
+  const parsed =
+    semverParse(stripped, { loose: true }) ??
+    semverParse(semverClean(stripped, { loose: true }) ?? '', { loose: true });
+  if (parsed) return parsed.prerelease.length > 0;
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a "Hide pre-releases" toggle button to the releases toolbar that filters out alpha, beta, rc, canary, and other pre-release versions.

### Changes
- **`src/lib/utils/semver.ts`** — Added `isPrerelease()` function that parses a version string and checks for a semver pre-release segment. Uses direct `semverParse` (not the lossy `coerce` path) to preserve pre-release identifiers.
- **`src/lib/components/repo/RepoReleases.svelte`** — Added `hidePrereleases` toggle state, `isStableRelease()` helper predicate, and filtering logic in `sortedGroups`. Summary line shows "Showing X of Y releases" when active. Toggle button placed between sort and view controls.
- **`src/lib/utils/release-grouping.semver.test.ts`** — Added 14 test cases for `isPrerelease()` covering stable versions, various pre-release identifiers, `refs/tags/` prefix, null/undefined, and non-version strings.

### Filter criteria
A release is hidden when:
- GitHub `prerelease` flag is `true`, OR
- The tag contains a semver pre-release segment (e.g. `-alpha.1`, `-beta.0`, `-rc.2`, `-canary.20240101`)

Groups with zero remaining releases after filtering are hidden entirely.