### PR TITLE
fix: invisible bullets in release notes markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "prepare": "husky",
+    "prepare": "svelte-kit sync && husky",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "format": "prettier --write .",

--- a/src/lib/components/ui/markdown/Markdown.svelte
+++ b/src/lib/components/ui/markdown/Markdown.svelte
@@ -76,6 +76,14 @@
     margin-bottom: 1em;
   }
 
+  .markdown-content :global(ul) {
+    list-style-type: disc;
+  }
+
+  .markdown-content :global(ol) {
+    list-style-type: decimal;
+  }
+
   .markdown-content :global(li) {
     margin-bottom: 0.25em;
   }


### PR DESCRIPTION
Release notes on `/r/:owner/:repo` rendered `<ul>`/`<ol>` without visible markers.

Root cause: Tailwind Preflight resets `ol, ul { list-style: none }` globally. The scoped CSS in `Markdown.svelte` restored margins but never opted back into `list-style-type`, so bullets and numbers were stripped from rendered markdown.

Fix: add `list-style-type: disc` (ul) and `decimal` (ol) to the scoped styles.

Also runs `svelte-kit sync` in the `prepare` script so `.svelte-kit/tsconfig.json` is generated on install — without it, vitest warns about a missing base tsconfig.

Verified: existing markdown tests pass (8/8), full suite passes (76/76).