### PR TITLE
feat(routing): drop /r prefix so host-swap deep-links from GitHub

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -34,22 +34,21 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY:
-            ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          
+
           # for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
           # AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # AWS_REGION: us-east-1
           # BEDROCK_MODEL_ID: <bedrock-model-id>
-          
+
           # for Google Vertex AI (https://docs.pullfrog.com/vertex)
           # VERTEX_SERVICE_ACCOUNT_JSON: >-
           #   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}

--- a/.junie/overview.md
+++ b/.junie/overview.md
@@ -42,7 +42,8 @@ RepoScoop transforms this experience by:
 
 1. **Routing Structure**
    - `/` - Home page with repository input form
-   - `/r/:owner/:repo` - Repository view page showing grouped releases
+   - `/:owner/:repo` - Repository view page showing grouped releases (trailing path ignored, e.g. `/:owner/:repo/releases`)
+   - `/r/:owner/:repo` - Redirects to `/:owner/:repo` (back-compat)
    - `/about` - Information about the project
 
 2. **Component Hierarchy**

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -67,7 +67,7 @@
 
       // Simulate a short delay to show loading state
       setTimeout(() => {
-        goto(`/r/${owner}/${repo}`);
+        goto(`/${owner}/${repo}`);
         isLoading = false;
       }, 500);
     } else {
@@ -76,7 +76,7 @@
   }
 
   function viewRecentRepo(repo: RecentRepo): void {
-    goto(`/r/${repo.owner}/${repo.repo}`);
+    goto(`/${repo.owner}/${repo.repo}`);
   }
 </script>
 

--- a/src/routes/[owner]/[repo]/[...rest]/+page.svelte
+++ b/src/routes/[owner]/[repo]/[...rest]/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import RepoPage from '$lib/components/repo/RepoPage.svelte';
+  // ponytail: [owner]/[repo]/[...rest] mirrors GitHub's URL shape so a host swap alone
+  // (github.com/o/r/releases -> reposcoop.../o/r/releases) deep-links correctly. Extra path
+  // after the repo name is intentionally ignored. Greedy [owner] is fine here because the only
+  // other root route is static `/`; add a static segment if a future 2-segment root route is needed.
+  const owner = $derived(page.params.owner!);
+  const repo = $derived(page.params.repo!);
+</script>
+
+<RepoPage {owner} {repo} />

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -80,6 +80,21 @@ describe('Home Page', () => {
     expect(navigation.goto).toHaveBeenCalledWith('/sveltejs/kit');
   });
 
+  it('should navigate to repo when clicking a recently viewed repo', async () => {
+    localStorageMock.setItem(
+      'recentRepos',
+      JSON.stringify([
+        { owner: 'sveltejs', repo: 'kit', fullName: 'sveltejs/kit', timestamp: new Date().toISOString() },
+      ]),
+    );
+
+    render(Page);
+
+    await page.getByText('sveltejs/kit').click();
+
+    expect(navigation.goto).toHaveBeenCalledWith('/sveltejs/kit');
+  });
+
   it('should save repository to recently viewed in localStorage', async () => {
     render(Page);
 

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -77,7 +77,7 @@ describe('Home Page', () => {
     // Wait for the timeout in the component
     await new Promise((resolve) => setTimeout(resolve, 600));
 
-    expect(navigation.goto).toHaveBeenCalledWith('/r/sveltejs/kit');
+    expect(navigation.goto).toHaveBeenCalledWith('/sveltejs/kit');
   });
 
   it('should save repository to recently viewed in localStorage', async () => {

--- a/src/routes/r/[owner]/[repo]/+page.svelte
+++ b/src/routes/r/[owner]/[repo]/+page.svelte
@@ -1,8 +1,0 @@
-<script lang="ts">
-  import { page } from '$app/state';
-  import RepoPage from '$lib/components/repo/RepoPage.svelte';
-  const owner = $derived(page.params.owner!);
-  const repo = $derived(page.params.repo!);
-</script>
-
-<RepoPage {owner} {repo} />

--- a/src/routes/r/[owner]/[repo]/+server.ts
+++ b/src/routes/r/[owner]/[repo]/+server.ts
@@ -1,0 +1,9 @@
+import { redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// ponytail: back-compat redirect for old /r/[owner]/[repo] bookmarks. Safe to remove after a
+// few months if analytics show no hits. Static segment `r` wins over the dynamic [owner] route,
+// so this is reached for /r/... paths and not shadowed.
+export const GET: RequestHandler = ({ params }) => {
+  throw redirect(307, `/${params.owner}/${params.repo}`);
+};


### PR DESCRIPTION
## Problem

Viewing a repo's changelog currently requires three manual URL edits: swap host (`github.com` → `reposcoop…`), remove `/releases`, and insert `/r`.

## Change

Canonical repo URL is now `/:owner/:repo` instead of `/r/:owner/:repo`. A `[...rest]` catch-all ignores any trailing path, so a **host swap alone** deep-links correctly:

- `reposcoop…/owner/repo` → repo view
- `reposcoop…/owner/repo/releases` → repo view
- `reposcoop…/owner/repo/releases/tag/@scope/pkg@1.2.3` → repo view

Old `/r/:owner/:repo` bookmarks redirect (307) to the new path.

## Verification

- `bun run check` — 0 errors
- `bun run test` — 95/95 passing
- `bun run lint` — clean