### PR TITLE
ci(pullfrog): route agent to GLM-5.2 via Z.AI Coding Plan

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -56,11 +56,9 @@ jobs:
           # VERTEX_LOCATION: global
           # VERTEX_MODEL_ID: <vertex-model-id>
 
-          # for any OpenAI-compatible endpoint — LiteLLM, Cloudflare AI Gateway,
-          # self-hosted vLLM (https://docs.pullfrog.com/openai-compatible)
-          # OPENAI_COMPATIBLE_BASE_URL: https://litellm.example.com/v1
-          # OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
-          # OPENAI_COMPATIBLE_MODEL: <model-id>
-          # both limits are required — set them to the real limits of that model
-          # OPENAI_COMPATIBLE_CONTEXT: "128000"
-          # OPENAI_COMPATIBLE_MAX_OUTPUT: "16384"
+          # GLM-5.2 via Z.AI Coding Plan (direct, not via the OpenCode router)
+          OPENAI_COMPATIBLE_BASE_URL: https://api.z.ai/api/coding/paas/v4
+          OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+          OPENAI_COMPATIBLE_MODEL: glm-5.2
+          OPENAI_COMPATIBLE_CONTEXT: '1000000'
+          OPENAI_COMPATIBLE_MAX_OUTPUT: '131072'


### PR DESCRIPTION
Switches the Pullfrog agent to GLM-5.2 served directly by Z.AI Coding Plan, instead of the OpenCode router.

## Changes
- Uncomment the OpenAI-compatible endpoint block in `pullfrog.yml` and fill it with Z.AI Coding Plan values: base URL `https://api.z.ai/api/coding/paas/v4`, model `glm-5.2`, context `1000000`, max output `131072` (per models.dev).
- Other provider keys (`ANTHROPIC_API_KEY`, `OPENCODE_API_KEY`, etc.) are left in place so one-off `--opus` / `--sonnet` flags still work.

## Required follow-ups (not in this PR)
1. Add a GitHub Actions secret named `OPENAI_COMPATIBLE_API_KEY` with a Z.AI Coding Plan key.
2. In the Pullfrog console, set the repo model to **Custom › OpenAI-compatible** so the endpoint owns the model selection.

When all five `OPENAI_COMPATIBLE_*` vars are present, Pullfrog materializes the OpenAI-compatible provider and routes the run through it.