### PR TITLE
fix(release-grouping): stop grouping releases under a phantom "Release" package

### DIFF
--- a/src/lib/utils/release-grouping.test.ts
+++ b/src/lib/utils/release-grouping.test.ts
@@ -206,6 +206,21 @@ describe('Release Grouping Utilities', () => {
       const patterns = detectPackagePatterns([]);
       expect(patterns).toEqual([]);
     });
+
+    it('does not detect generic words like "Release" or "Version" as package patterns', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const releases: any[] = [
+        { tag_name: 'v4.8.1', name: 'Release v4.8.1' },
+        { tag_name: 'v4.8.0', name: 'Release v4.8.0' },
+        { tag_name: 'v3.0.0', name: 'Version 3.0.0' },
+      ];
+
+      const patterns = detectPackagePatterns(releases);
+      expect(patterns).not.toContain('Release');
+      expect(patterns).not.toContain('release');
+      expect(patterns).not.toContain('Version');
+      expect(patterns).not.toContain('default');
+    });
   });
 
   describe('groupReleasesByPackage', () => {
@@ -253,6 +268,26 @@ describe('Release Grouping Utilities', () => {
 
       expect(result.groups).toEqual([]);
       expect(result.totalReleases).toBe(0);
+    });
+
+    it('treats "Release vX.Y.Z" names as default and groups under repo name (e.g. less.js)', () => {
+      // Newer less.js releases use name "Release vX.Y.Z" while the tag stays "vX.Y.Z";
+      // "Release" must not become its own package group.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const lessReleases: any[] = [
+        { tag_name: 'v4.8.1', name: 'Release v4.8.1', published_at: '2026-07-27T00:00:00Z' },
+        { tag_name: 'v4.8.0', name: 'Release v4.8.0', published_at: '2026-07-22T00:00:00Z' },
+        { tag_name: 'v1.7.5', name: 'v1.7.5', published_at: '2014-11-01T00:00:00Z' },
+      ];
+
+      const result = groupReleasesByPackage(lessReleases, 'less.js');
+
+      // Single group under the repo name, no "Release" group
+      expect(result.groups.map((g) => g.name)).toEqual(['less.js']);
+      expect(result.totalReleases).toBe(3);
+
+      // Newest first
+      expect(result.groups[0].releases.map((r) => r.tag_name)).toEqual(['v4.8.1', 'v4.8.0', 'v1.7.5']);
     });
   });
 

--- a/src/lib/utils/release-grouping.ts
+++ b/src/lib/utils/release-grouping.ts
@@ -39,6 +39,16 @@ export interface GroupedReleases {
 }
 
 /**
+ * Generic descriptors that appear in release titles but are not package names
+ * (e.g. "Release v4.8.1", "Version 6.0.0"). These collapse to the default group.
+ */
+const DEFAULT_PACKAGE_NAMES = new Set(['default', 'version', 'release']);
+
+function isDefaultPackageName(name: string): boolean {
+  return !name || DEFAULT_PACKAGE_NAMES.has(name.trim().toLowerCase());
+}
+
+/**
  * Common patterns for package names in release titles
  */
 const PACKAGE_PATTERNS = [
@@ -111,8 +121,13 @@ export function extractPackageInfo(title: string): { packageName: string; versio
   const parts = title.split(/[\s-]/);
   if (parts.length > 1) {
     const first = parts[0];
-    // Treat version-like or generic 'Version' prefixes as default
-    if (first.toLowerCase() === 'version' || first.toLowerCase() === 'v' || /^\d+(?:\.\d+){1,3}$/.test(first)) {
+    // Treat version-like or generic 'Version'/'Release' prefixes as default
+    if (
+      first.toLowerCase() === 'version' ||
+      first.toLowerCase() === 'release' ||
+      first.toLowerCase() === 'v' ||
+      /^\d+(?:\.\d+){1,3}$/.test(first)
+    ) {
       return {
         packageName: 'default',
         version: title.replace(/^version\s+|^v\s+/i, '').trim(),
@@ -146,15 +161,11 @@ export function detectPackagePatterns(releases: Release[]): string[] {
     const tagInfo = extractPackageInfo(release.tag_name);
     const nameInfo = extractPackageInfo(release.name);
 
-    if (tagInfo?.packageName && tagInfo.packageName !== 'default' && tagInfo.packageName.toLowerCase() !== 'version') {
+    if (tagInfo?.packageName && !isDefaultPackageName(tagInfo.packageName)) {
       patterns.add(tagInfo.packageName);
     }
 
-    if (
-      nameInfo?.packageName &&
-      nameInfo.packageName !== 'default' &&
-      nameInfo.packageName.toLowerCase() !== 'version'
-    ) {
+    if (nameInfo?.packageName && !isDefaultPackageName(nameInfo.packageName)) {
       patterns.add(nameInfo.packageName);
     }
   }
@@ -177,14 +188,9 @@ export function groupReleasesByPackage(releases: Release[], repoName?: string): 
 
     if (!packageInfo) {
       packageInfo = extractPackageInfo(release.name);
-    } else if (packageInfo.packageName === 'default') {
+    } else if (isDefaultPackageName(packageInfo.packageName)) {
       const nameInfo = extractPackageInfo(release.name);
-      if (
-        nameInfo &&
-        nameInfo.packageName &&
-        nameInfo.packageName !== 'default' &&
-        nameInfo.packageName.toLowerCase() !== 'version'
-      ) {
+      if (nameInfo && nameInfo.packageName && !isDefaultPackageName(nameInfo.packageName)) {
         packageInfo = nameInfo;
       }
     }
@@ -222,9 +228,7 @@ export function groupReleasesByPackage(releases: Release[], repoName?: string): 
   // Determine repo group name
   const repoGroupName = repoName && repoName.trim().length > 0 ? repoName : 'repository';
   // Consider patterns meaningful if there is at least one non-default release
-  const nonDefaultCount = groupedReleases.filter(
-    (r) => r.packageName && r.packageName !== 'default' && r.packageName.toLowerCase() !== 'version',
-  ).length;
+  const nonDefaultCount = groupedReleases.filter((r) => !isDefaultPackageName(r.packageName)).length;
   const hasPatterns = nonDefaultCount >= 1;
 
   // Group by computed group key
@@ -232,7 +236,7 @@ export function groupReleasesByPackage(releases: Release[], repoName?: string): 
 
   for (const release of groupedReleases) {
     let pkg = release.packageName;
-    if (pkg.toLowerCase() === 'version') {
+    if (isDefaultPackageName(pkg)) {
       pkg = 'default';
       release.packageName = 'default';
     }


### PR DESCRIPTION
## Problem

On repos like [less/less.js](https://reposcoop.com/less/less.js), releases split into two groups: the library name and a phantom "Release" group, with newer releases landing under "Release".

## Root cause

less.js changed its GitHub release *name* from `vX.Y.Z` to `Release vX.Y.Z` (tag is still `vX.Y.Z`).

1. Tag `vX.Y.Z` matches the bare-version pattern → `packageName = "default"`.
2. Grouping falls back to the name; `Release vX.Y.Z` matches the `packageName vX.Y.Z` pattern → `packageName = "Release"`.
3. The fallback guard rejected the override only for `"version"`, not `"release"`, so `packageName` became `"Release"`.
4. Once any release did this, `hasPatterns` flipped true and those releases grouped under `"Release"` while plain-tag releases stayed under the repo name.

The word "version" was already special-cased as a generic descriptor; "release" was just missing from that list.

## Fix

Treat `release` (case-insensitive) the same as `version`/`default` via a single `isDefaultPackageName` helper, applied at the six grouping decision points in `src/lib/utils/release-grouping.ts`. Also added `release` to the generic-prefix check in `extractPackageInfo`'s fallback branch.

No UI changes — groups render by name and now collapse to the single repo group.

## Verification

- `bun run test` → 98/98 pass
- `prettier --check` + `eslint` clean on touched files
- New regression tests:
  - `groupReleasesByPackage` with less.js-shaped input (tag `vX.Y.Z` + name `Release vX.Y.Z`) → single `less.js` group, newest first
  - `detectPackagePatterns` does not emit `Release`/`Version`/`default`
